### PR TITLE
防止Remove:ContentRemoveTags污染原来的Document

### DIFF
--- a/extract/content.go
+++ b/extract/content.go
@@ -175,8 +175,9 @@ type countInfo struct {
 	LeafList []int
 }
 
-func NewContent(doc *goquery.Document, lang string, originTitle string, originUrl string) *Content {
-	originDoc := goquery.CloneDocument(doc)
+func NewContent(docOrg *goquery.Document, lang string, originTitle string, originUrl string) *Content {
+	originDoc := goquery.CloneDocument(docOrg)
+	doc := goquery.CloneDocument(docOrg)
 	doc.Find(ContentRemoveTags).Remove()
 
 	// 标题相似度阈值判定


### PR DESCRIPTION
外部的doc调用NewContent后,doc会被ContentRemoveTags影响